### PR TITLE
Allocate new ID range for Tiago Lubiana.

### DIFF
--- a/src/ontology/fbbi-idranges.owl
+++ b/src/ontology/fbbi-idranges.owl
@@ -24,6 +24,18 @@ AnnotationProperty: comment:
 
 Datatype: idrange:1
     Annotations:
+        allocatedto: "Historical"
+    EquivalentTo:
+        xsd:integer[>= 0, < 100000]
+
+Datatype: idrange:2
+    Annotations:
         allocatedto: "Damien Goutte-Gattat"
     EquivalentTo:
         xsd:integer[>= 100000, < 110000]
+
+Datatype: idrange:3
+    Annotations:
+        allocatedto: "Tiago Lubiana"
+    EquivalentTo:
+        xsd:integer[>= 110000, < 120000]


### PR DESCRIPTION
From now on there may be more than one editor introducing changes to the ontology (including to add new terms), so to avoid any issue with concurrent pull requests all editors should have their own ID range.

This commit therefore adds a new ID range for Tiago Lubiana from German BioImaging.

It also explicitly reserves the 0-100000 range for "historical purposes", to make it clear that new terms should now use IDs from one of the explicitly allocated ranges.