### PR TITLE
Fix cryo-FIB-SEM-related terms

### DIFF
--- a/src/ontology/fbbi-edit.owl
+++ b/src/ontology/fbbi-edit.owl
@@ -6616,9 +6616,9 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/FBbi_00100016> "cryogenic scanning electron microscopy")
 EquivalentClasses(<http://purl.obolibrary.org/obo/FBbi_00100016> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/FBbi_00000257> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/FBbi_00000346> <http://purl.obolibrary.org/obo/FBbi_00000013>)))
 
-# Class: <http://purl.obolibrary.org/obo/FBbi_00100017> (cryogenic serial block face scanning electron microscopy)
+# Class: <http://purl.obolibrary.org/obo/FBbi_00100017> (cryogenic focused ion beam scanning electron microscopy)
 
-AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:27693309") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/FBbi_00100017> "Cryogenic serial block-face scanning electron microscopy is a volumetric imaging technique in which the surface of a biological specimen preserved in its near-native, vitrified state is imaged by a scanning electron microscope, then ablated by a focused ion beam (FIB-SEM) to reveal a new surface, enabling three-dimensional ultrastructural reconstruction of cells and tissues without the artifacts introduced by chemical fixation or resin embedding.")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:27693309") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/FBbi_00100017> "Cryogenic focused ion beam scanning electron microscopy is a volumetric imaging technique in which the surface of a biological specimen preserved in its near-native, vitrified state is imaged by a scanning electron microscope, then ablated by a focused ion beam (FIB-SEM) to reveal a new surface, enabling three-dimensional ultrastructural reconstruction of cells and tissues without the artifacts introduced by chemical fixation or resin embedding.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> <http://purl.obolibrary.org/obo/FBbi_00100017> <https://orcid.org/0000-0002-6095-8718>)
 AnnotationAssertion(<http://purl.org/dc/terms/date> <http://purl.obolibrary.org/obo/FBbi_00100017> "2026-03-13T13:54:56Z"^^xsd:dateTime)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/FBbi_00100017> "cryo FIB-SEM slice and view")
@@ -6627,8 +6627,8 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/FBbi_00100017> "cryo-serial block face SEM")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/FBbi_00100017> "cryo-serial block face scanning electron microscopy")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/FBbi_00100017> "serial block face cryo-SEM")
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/FBbi_00100017> "cryogenic serial block face scanning electron microscopy")
-EquivalentClasses(<http://purl.obolibrary.org/obo/FBbi_00100017> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/FBbi_00000585> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/FBbi_00000346> <http://purl.obolibrary.org/obo/FBbi_00000013>)))
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/FBbi_00100017> "cryogenic focused ion beam scanning electron microscopy")
+EquivalentClasses(<http://purl.obolibrary.org/obo/FBbi_00100017> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/FBbi_00050000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/FBbi_00000346> <http://purl.obolibrary.org/obo/FBbi_00000013>)))
 
 # Class: <http://purl.obolibrary.org/obo/FBbi_00100018> (optical anisotropy)
 

--- a/src/ontology/fbbi-edit.owl
+++ b/src/ontology/fbbi-edit.owl
@@ -6439,13 +6439,14 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/FBbi_00001012> "fixation method")
 SubClassOf(<http://purl.obolibrary.org/obo/FBbi_00001012> <http://purl.obolibrary.org/obo/FBbi_00000001>)
 
-# Class: <http://purl.obolibrary.org/obo/FBbi_00050000> (focussed ion beam scanning electron microscopy (FIB-SEM))
+# Class: <http://purl.obolibrary.org/obo/FBbi_00050000> (focused ion beam scanning electron microscopy)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:22119321") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/FBbi_00050000> "A method of reconstructing 3D structure by combining focussed ion beam milling to remove sucessive layers from a sample block with scanning EM to image the exposed surface between each milling step.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/FBbi_00050000> "FIB-SEM")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/OMO_0003000>) <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/FBbi_00050000> "FIB-SEM")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/FBbi_00050000> "focussed ion beam scanning electron microscopy")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/FBbi_00050000> "image")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/FBbi_00050000> "FBbi:00050000")
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/FBbi_00050000> "focussed ion beam scanning electron microscopy (FIB-SEM)")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/FBbi_00050000> "focused ion beam scanning electron microscopy")
 SubClassOf(<http://purl.obolibrary.org/obo/FBbi_00050000> <http://purl.obolibrary.org/obo/FBbi_00000373>)
 
 # Class: <http://purl.obolibrary.org/obo/FBbi_00100000> (SNAP-tag)

--- a/src/ontology/fbbi-edit.owl
+++ b/src/ontology/fbbi-edit.owl
@@ -5979,14 +5979,16 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/FBbi_00000584> "X-Rhodamine")
 SubClassOf(<http://purl.obolibrary.org/obo/FBbi_00000584> <http://purl.obolibrary.org/obo/FBbi_00000455>)
 
-# Class: <http://purl.obolibrary.org/obo/FBbi_00000585> (serial block face SEM (SBFSEM))
+# Class: <http://purl.obolibrary.org/obo/FBbi_00000585> (serial block face scanning electron microscopy)
 
-AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:15514700") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/FBbi_00000585> "A method of reconstructing 3D structure by combining serial sectioning with scanning EM.")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:15514700") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/FBbi_00000585> "A method of reconstructing 3D structure by combining in-situ serial sectioning with scanning EM.")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#created_by> <http://purl.obolibrary.org/obo/FBbi_00000585> "jm")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.obolibrary.org/obo/FBbi_00000585> "2010-09-02T05:10:33Z")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/OMO_0003000>) <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/FBbi_00000585> "SBF-SEM")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/FBbi_00000585> "image")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/FBbi_00000585> "FBbi:00000585")
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/FBbi_00000585> "serial block face SEM (SBFSEM)")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "doi:10.1038/s43586-022-00131-9") rdfs:comment <http://purl.obolibrary.org/obo/FBbi_00000585> "This term does not encompass methods where the in-situ milling is performed using a focused ion beam (FIB-SEM). We follow the nomenclature of Peddie et al. (2022), in which SBF-SEM and FIB-SEM are considered as two unrelated methods.")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/FBbi_00000585> "serial block face scanning electron microscopy")
 SubClassOf(<http://purl.obolibrary.org/obo/FBbi_00000585> <http://purl.obolibrary.org/obo/FBbi_00000373>)
 
 # Class: <http://purl.obolibrary.org/obo/FBbi_00000586> (elastic scattering of electrons)


### PR DESCRIPTION
This PR implements the fix proposed in #52 ([this comment](https://github.com/foundingGIDE/fbbi/issues/52#issuecomment-4381958529)).

That is, `FBbi:00100017` is renamed to “cryogenic focused ion beam scanning electron microscopy” (cryo-FIB-SEM), and re-classified under `FBbi:00050000` (“focused ion beam scanning electron microscopy”), so that `FBbi:00050000` covers all forms of FIB-SEM (indifferently in cryogenic conditions or at RT) whereas `FBbi:00100017` covers specifically the cryogenic form.

closes #52 